### PR TITLE
Problem: source code reloading is enabled by default

### DIFF
--- a/install/storage-service.gunicorn-config.py
+++ b/install/storage-service.gunicorn-config.py
@@ -1,55 +1,68 @@
 # Documentation: http://docs.gunicorn.org/en/stable/configure.html
 # Example: https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py
 
+import os
+
 # http://docs.gunicorn.org/en/stable/settings.html#user
-user = "archivematica"
+user = os.environ.get('SS_GUNICORN_USER', 'archivematica')
 
 # http://docs.gunicorn.org/en/stable/settings.html#group
-group = "archivematica"
+group = os.environ.get('SS_GUNICORN_GROUP', 'archivematica')
 
 # http://docs.gunicorn.org/en/stable/settings.html#bind
-bind = "127.0.0.1:8001"
+bind = os.environ.get('SS_GUNICORN_BIND', '127.0.0.1:8001')
 
 # http://docs.gunicorn.org/en/stable/settings.html#workers
-workers = "4"
+workers = os.environ.get('SS_GUNICORN_WORKERS', '4')
+
+# http://docs.gunicorn.org/en/stable/settings.html#worker-class
+worker_class = os.environ.get('SS_GUNICORN_WORKER_CLASS', 'gevent')
 
 # http://docs.gunicorn.org/en/stable/settings.html#timeout
-timeout = "172800"
+timeout = os.environ.get('SS_GUNICORN_TIMEOUT', '172800')
 
 # http://docs.gunicorn.org/en/stable/settings.html#reload
-reload = False
+reload = os.environ.get('SS_GUNICORN_RELOAD', 'false')
+
+# http://docs.gunicorn.org/en/stable/settings.html#reload-engine
+reload_engine = os.environ.get('SS_GUNICORN_RELOAD_ENGINE', 'auto')
 
 # http://docs.gunicorn.org/en/stable/settings.html#chdir
-chdir = "/usr/lib/archivematica/storage-service"
+chdir = os.environ.get('SS_GUNICORN_CHDIR', '/usr/lib/archivematica/storage-service')
 
 # http://docs.gunicorn.org/en/stable/settings.html#raw-env
-raw_env = [
-    "EMAIL_HOST_PASSWORD=",
-    "SS_DB_NAME=/var/archivematica/storage-service/storage.db",
-    "SS_DB_PASSWORD=",
-    "SS_DB_USER=",
-    "SS_DB_HOST=",
-    "DJANGO_SETTINGS_MODULE=storage_service.settings.production",
-    "EMAIL_PORT=25",
-    "DJANGO_SECRET_KEY=<replace-with-key>",
-    "EMAIL_HOST_USER=",
-    "EMAIL_HOST=localhost",
-]
+envs = (
+    ("EMAIL_HOST_PASSWORD", ""),
+    ("SS_DB_NAME", "/var/archivematica/storage-service/storage.db"),
+    ("SS_DB_PASSWORD", ""),
+    ("SS_DB_USER", ""),
+    ("SS_DB_HOST", ""),
+    ("DJANGO_SETTINGS_MODULE", "storage_service.settings.production"),
+    ("EMAIL_PORT", "25"),
+    ("DJANGO_SECRET_KEY", "<replace-with-key>"),
+    ("EMAIL_HOST_USER", ""),
+    ("EMAIL_HOST", "localhost"),
+)
+raw_env = []
+for e in envs:
+    if e[0] in os.environ:
+        continue
+    raw_env.append('='.join(e))
 
 # http://docs.gunicorn.org/en/stable/settings.html#accesslog
-accesslog = "/var/log/archivematica/storage-service/gunicorn.access_log"
+accesslog = os.environ.get('SS_GUNICORN_ACCESSLOG', '/var/log/archivematica/storage-service/gunicorn.access_log')
 
 # http://docs.gunicorn.org/en/stable/settings.html#errorlog
-errorlog = "/var/log/archivematica/storage-service/gunicorn.error_log"
+errorlog = os.environ.get('SS_GUNICORN_ERRORLOG', '/var/log/archivematica/storage-service/gunicorn.error_log')
 
 # http://docs.gunicorn.org/en/stable/settings.html#loglevel
-loglevel = "info"
+loglevel = os.environ.get('SS_GUNICORN_LOGLEVEL', 'info')
 
 # http://docs.gunicorn.org/en/stable/settings.html#proc-name
-proc_name = "archivematica-storage-service"
+proc_name = os.environ.get('SS_GUNICORN_PROC_NAME', 'archivematica-storage-service')
 
 # http://docs.gunicorn.org/en/stable/settings.html#pythonpath
-pythonpath = ""
+pythonpath = os.environ.get('SS_GUNICORN_PYTHONPATH', '')
 
 # http://docs.gunicorn.org/en/stable/settings.html#sendfile
-sendfile = True
+sendfile = os.environ.get('SS_GUNICORN_SENDFILE', 'false')


### PR DESCRIPTION
Gunicorn's source code auto-reloading is very useful in development environments but it should not be used in production. The Dockerfile in the repo targets production environments.
Developers can still change the defaults via environment strings, e.g. with this PR you can redefine Gunicorn settings with strings like `GUNICORN_RELOAD` or`GUNICORN_RELOAD_ENGINE`.

Related: https://github.com/JiscRDSS/archivematica/pull/10