### PR TITLE
Make shibboleth optional

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,3 +7,4 @@ coverage==4.2
 pytest-django
 tox
 vcrpy>=1.0.0
+ipdb

--- a/storage_service/common/templatetags/user.py
+++ b/storage_service/common/templatetags/user.py
@@ -1,0 +1,13 @@
+from django import template
+from django.core.urlresolvers import reverse
+
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def logout_link(context):
+    if context.get('logout_link'):
+        return context['logout_link']
+    else:
+        return reverse('logout')

--- a/storage_service/storage_service/settings/base.py
+++ b/storage_service/storage_service/settings/base.py
@@ -164,7 +164,6 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
-                'shibboleth.context_processors.logout_link',
             ],
             'debug': DEBUG,
         },
@@ -177,15 +176,14 @@ TEMPLATES = [
 # ######### AUTHENTICATION CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#authentication-backends
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-    'shibboleth.backends.ShibbolethRemoteUserBackend',
-)
+]
 # ######### END AUTHENTICATION CONFIGURATION
 
 # ######### MIDDLEWARE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     # 'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -194,11 +192,10 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'common.middleware.CustomShibbolethRemoteUserMiddleware',
     'common.middleware.LoginRequiredMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+]
 # ######## END MIDDLEWARE CONFIGURATION
 
 
@@ -209,7 +206,7 @@ ROOT_URLCONF = '%s.urls' % SITE_NAME
 
 
 # ######## APP CONFIGURATION
-DJANGO_APPS = (
+DJANGO_APPS = [
     # Default Django apps:
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -224,20 +221,19 @@ DJANGO_APPS = (
     # Admin panel and documentation:
     'django.contrib.admin',
     # 'django.contrib.admindocs',
-)
+]
 
-THIRD_PARTY_APPS = (
+THIRD_PARTY_APPS = [
     'tastypie',  # REST framework
-    'shibboleth', # Shibboleth authentication
     'longerusername', # Longer (> 30 characters) username
-)
+]
 
 # Apps specific for this project go here.
-LOCAL_APPS = (
+LOCAL_APPS = [
     'administration',
     'common',
     'locations',
-)
+]
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
@@ -245,10 +241,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 
 # ######## LOGIN REQUIRED MIDDLEWARE CONFIGURATION
-# LOGIN_URL = '/login/'
-LOGIN_URL = '/Shibboleth.sso/Login'
-SHIBBOLETH_LOGOUT_URL = '/Shibboleth.sso/Logout?target=%s'
-SHIBBOLETH_LOGOUT_REDIRECT_URL = '/logged-out'
+LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/'
 LOGIN_EXEMPT_URLS = (
     r'^api/',
@@ -341,17 +334,46 @@ SESSION_COOKIE_NAME = 'storageapi_sessionid'
 WSGI_APPLICATION = '%s.wsgi.application' % SITE_NAME
 # ######## END WSGI CONFIGURATION
 
-# ######### SHIBBOLETH CONFIGURATION
-SHIBBOLETH_REMOTE_USER_HEADER = 'HTTP_EPPN'
-SHIBBOLETH_ATTRIBUTE_MAP = {
-    # Automatic user fields
-    'HTTP_GIVENNAME': (False, 'first_name'),
-    'HTTP_SN': (False, 'last_name'),
-    'HTTP_MAIL': (False, 'email'),
-    # Entitlement field (which we handle manually)
-    'HTTP_ENTITLEMENT': (True, 'entitlement'),
-}
+ALLOW_USER_EDITS = True
 
-# If the user has this entitlement, they will be a superuser/admin
-SHIBBOLETH_ADMIN_ENTITLEMENT = 'preservation-admin'
-# ######### END SHIBBOLETH CONFIGURATION
+
+def is_true(env_str):
+    return env_str.lower() in ['true', 'yes', 'on', '1']
+
+SHIBBOLETH_AUTHENTICATION = is_true(environ.get('SS_SHIBBOLETH_AUTHENTICATION', ''))
+if SHIBBOLETH_AUTHENTICATION:
+    SHIBBOLETH_LOGOUT_URL = '/Shibboleth.sso/Logout?target=%s'
+    SHIBBOLETH_LOGOUT_REDIRECT_URL = '/logged-out'
+
+    SHIBBOLETH_REMOTE_USER_HEADER = 'HTTP_EPPN'
+    SHIBBOLETH_ATTRIBUTE_MAP = {
+        # Automatic user fields
+        'HTTP_GIVENNAME': (False, 'first_name'),
+        'HTTP_SN': (False, 'last_name'),
+        'HTTP_MAIL': (False, 'email'),
+        # Entitlement field (which we handle manually)
+        'HTTP_ENTITLEMENT': (True, 'entitlement'),
+    }
+
+    # If the user has this entitlement, they will be a superuser/admin
+    SHIBBOLETH_ADMIN_ENTITLEMENT = 'preservation-admin'
+
+    TEMPLATES[0]['OPTIONS']['context_processors'] += [
+        'shibboleth.context_processors.logout_link',
+    ]
+
+    AUTHENTICATION_BACKENDS += [
+        'shibboleth.backends.ShibbolethRemoteUserBackend',
+    ]
+
+    # Insert Shibboleth after the authentication middleware
+    MIDDLEWARE_CLASSES.insert(
+        MIDDLEWARE_CLASSES.index(
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+        ) + 1,
+        'common.middleware.CustomShibbolethRemoteUserMiddleware',
+    )
+
+    INSTALLED_APPS += ['shibboleth']
+
+    ALLOW_USER_EDITS = False

--- a/storage_service/storage_service/tests/test_shibboleth.py
+++ b/storage_service/storage_service/tests/test_shibboleth.py
@@ -1,8 +1,11 @@
+import pytest
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.conf import settings
 
 
+@pytest.mark.skipif(not settings.SHIBBOLETH_AUTHENTICATION,
+                    reason='tests will only pass if Shibboleth is enabled')
 @override_settings(STATICFILES_STORAGE=None)
 class TestShibbolethLogin(TestCase):
     def test_with_no_shibboleth_headers(self):

--- a/storage_service/storage_service/tests/test_shibboleth.py
+++ b/storage_service/storage_service/tests/test_shibboleth.py
@@ -1,8 +1,9 @@
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.conf import settings
 
 
+@override_settings(STATICFILES_STORAGE=None)
 class TestShibbolethLogin(TestCase):
     def test_with_no_shibboleth_headers(self):
         response = self.client.get('/')
@@ -17,7 +18,8 @@ class TestShibbolethLogin(TestCase):
             'HTTP_EPPN': 'testuser',
             'HTTP_GIVENNAME': 'Test',
             'HTTP_SN': 'User',
-            'HTTP_MAIL': 'test@example.com'
+            'HTTP_MAIL': 'test@example.com',
+            'HTTP_ENTITLEMENT': 'preservation-user',
         }
 
         response = self.client.get('/', **shib_headers)
@@ -36,7 +38,8 @@ class TestShibbolethLogin(TestCase):
             'HTTP_EPPN': 'testuser',
             'HTTP_GIVENNAME': 'Test',
             'HTTP_SN': 'User',
-            'HTTP_MAIL': 'test@example.com'
+            'HTTP_MAIL': 'test@example.com',
+            'HTTP_ENTITLEMENT': 'preservation-user',
         }
 
         response = self.client.get('/', **shib_headers)
@@ -50,7 +53,8 @@ class TestShibbolethLogin(TestCase):
             'HTTP_EPPN': long_email,
             'HTTP_GIVENNAME': 'Test',
             'HTTP_SN': 'User',
-            'HTTP_MAIL': 'test@example.com'
+            'HTTP_MAIL': 'test@example.com',
+            'HTTP_ENTITLEMENT': 'preservation-user',
         }
 
         response = self.client.get('/', **shib_headers)

--- a/storage_service/storage_service/urls.py
+++ b/storage_service/storage_service/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 import django.contrib.auth.views
@@ -29,8 +30,13 @@ urlpatterns = [
     url(r'^i18n/', include('django.conf.urls.i18n', namespace='i18n')),
 
     url(r'^logged-out/', TemplateView.as_view(template_name='logged_out.html')),
-    url(r'^shib/', include('shibboleth.urls', namespace='shibboleth')),
 ]
+
+
+if 'shibboleth' in settings.INSTALLED_APPS:
+    urlpatterns += [
+        url(r'^shib/', include('shibboleth.urls', namespace='shibboleth')),
+    ]
 
 
 def startup():

--- a/storage_service/templates/administration/user_list.html
+++ b/storage_service/templates/administration/user_list.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-  {% if user.is_superuser %}
+  {% if user.is_superuser and allow_user_edits %}
     <p><a href="{% url 'user_create' %}">{% trans "Create New User" %}</a></p>
   {% endif %}
   <table class="datatable">
@@ -27,10 +27,12 @@
         <td>{{ user_display.is_superuser|yesno:_("True,False") }}</td>
         <td>{{ user_display.is_active|yesno:_("True,False") }}</td>
         <td>
-          {% if user.is_superuser %}
-            <a class="btn btn-primary edit small" href="{% url 'user_edit' user_display.id %}">{% trans "Edit" %}</a>
-          {% elif user.id == user_display.id %}
-            <a class="btn btn-primary edit small" href="{% url 'user_detail' user_display.id %}">{% trans "View" %}</a>
+          {% if user.is_superuser or user.id == user_display.id %}
+            {% if allow_user_edits %}
+              <a class="btn btn-primary edit small" href="{% url 'user_edit' user_display.id %}">{% trans "Edit" %}</a>
+            {% else %}
+              <a class="btn btn-primary edit small" href="{% url 'user_detail' user_display.id %}">{% trans "View" %}</a>
+            {% endif %}
           {% endif %}
         </td>
       </tr>

--- a/storage_service/templates/base.html
+++ b/storage_service/templates/base.html
@@ -1,5 +1,7 @@
 {% load staticfiles %}
 {% load i18n %}
+{% load user %}
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -52,7 +54,7 @@
               <li><a href="{% url 'package_list' %}">{% trans "Packages" %}</a></li>
               <li><a href="{% url 'settings_edit' %}">{% trans "Administration" %}</a></li>
               {% if user.is_authenticated %}
-              <li><a href="{{ logout_link }}">{% trans "Log out" %}</a></li>
+              <li><a href="{% logout_link %}">{% trans "Log out" %}</a></li>
               {% endif %}
             </ul>
           </div><!--/.nav-collapse -->


### PR DESCRIPTION
Allows Shibboleth auth to be switched on and off from the environment using ARCHIVEMATICA_DASHBOARD_SHIBBOLETH_AUTHENTICATION. Enabling this setting will switch on Shibboleth middleware and other settings.

It also toggles an ALLOW_USER_EDITS setting so that users can be editable and change their passwords under normal (model) authentication, but see a read only version of that with Shibboleth. This is a concept that could be extended to other forms of remote authentication. Some of the work here is restoring code that was removed in #3 and making it conditional on ALLOW_USER_EDITS.

The Shibboleth tests are passing again. There are more test failures in other areas of the project, a lot to do with filesystem permissions.

See also https://github.com/JiscRDSS/archivematica/pull/20 and on RDSS https://github.com/JiscRDSS/rdss-archivematica/pull/25