### PR TITLE
Locations: add global default location setting

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import os
+import re
 import shutil
 import urllib
 
@@ -12,6 +13,8 @@ import urllib
 from django.conf import settings
 from django.conf.urls import url
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
 from django.forms.models import model_to_dict
 from django.utils.translation import ugettext as _
 
@@ -28,6 +31,7 @@ from tastypie.validation import CleanedDataFormValidation
 from tastypie.utils import trailing_slash
 
 # This project, alphabetical
+from administration.models import Settings
 from common import utils
 from locations.api.sword import views as sword_views
 
@@ -259,10 +263,10 @@ class LocationResource(ModelResource):
 
     def prepend_urls(self):
         return [
+            url(r"^(?P<resource_name>%s)/default/(?P<purpose>[A-Z]{2})%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('default'), name="default_location"),
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/browse%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('browse'), name="browse"),
             # FEDORA/SWORD2 endpoints
             url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)/sword/collection%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('sword_collection'), name="sword_collection"),
-
         ]
 
     def decode_path(self, path):
@@ -271,6 +275,26 @@ class LocationResource(ModelResource):
     def get_objects(self, space, path):
         message = _('This method should be accessed via a versioned subclass')
         raise NotImplementedError(message)
+
+    def default(self, request, **kwargs):
+        """ Redirects to the default location for the given purpose. """
+        # Tastypie API checks
+        self.method_check(request, allowed=['get', 'post'])
+        self.is_authenticated(request)
+        self.throttle_check(request)
+        self.log_throttled_access(request)
+
+        try:
+            name = 'default_{}_location'.format(kwargs['purpose'])
+            uuid = Settings.objects.get(name=name).value
+        except (Settings.DoesNotExist, KeyError):
+            return http.HttpNotFound('Default location not defined for this purpose.')
+
+        return HttpResponseRedirect(reverse('api_dispatch_detail', kwargs={
+            'api_name': 'v2',
+            'resource_name': 'location',
+            'uuid': uuid,
+        }))
 
     @_custom_endpoint(expected_methods=['get'])
     def browse(self, request, bundle, **kwargs):
@@ -412,6 +436,8 @@ class PackageResource(ModelResource):
     current_full_path = fields.CharField(attribute='full_path', readonly=True)
     related_packages = fields.ManyToManyField('self', 'related_packages', null=True)
 
+    default_location_regex = re.compile(r'\/api\/v2\/location\/default\/(?P<purpose>[A-Z]{2})\/?')
+
     class Meta:
         queryset = Package.objects.all()
         authentication = MultiAuthentication(BasicAuthentication(), ApiKeyAuthentication(), SessionAuthentication())
@@ -464,6 +490,34 @@ class PackageResource(ModelResource):
         """Customize serialization of misc_attributes."""
         # Serialize JSONField as dict, not as repr of a dict
         return bundle.obj.misc_attributes
+
+    def hydrate_current_location(self, bundle):
+        try:
+            current_location = bundle.data['current_location']
+        except KeyError:
+            return bundle
+        matches = self.default_location_regex.match(current_location)
+        LOGGER.debug("current_location=%s", current_location)
+        try:
+            purpose = matches.group('purpose')
+        except AttributeError:
+            LOGGER.debug("attribute error")
+            return bundle
+        try:
+            name = 'default_{}_location'.format(purpose)
+            uuid = Settings.objects.get(name=name).value
+        except (Settings.DoesNotExist, KeyError):
+            LOGGER.debug("setting does not exist name = %s", name)
+            return bundle
+
+        a = reverse('api_dispatch_detail', kwargs={
+            'api_name': 'v2',
+            'resource_name': 'location',
+            'uuid': uuid,
+        })
+        LOGGER.debug("---> %s", a)
+        bundle.data['current_location'] = a
+        return bundle
 
     def obj_create(self, bundle, **kwargs):
         bundle = super(PackageResource, self).obj_create(bundle, **kwargs)

--- a/storage_service/locations/forms.py
+++ b/storage_service/locations/forms.py
@@ -163,9 +163,11 @@ class SwiftForm(forms.ModelForm):
 
 
 class LocationForm(forms.ModelForm):
+    default = forms.BooleanField(required=False)
+
     class Meta:
         model = models.Location
-        fields = ('purpose', 'pipeline', 'relative_path', 'description', 'quota', 'enabled')
+        fields = ('purpose', 'pipeline', 'relative_path', 'description', 'quota', 'enabled', 'default')
         widgets = {
             'purpose': DisableableSelectWidget(),
         }
@@ -189,6 +191,7 @@ class LocationForm(forms.ModelForm):
         self.fields['purpose'].widget.disabled_choices = blacklist
         # Associated with all enabled pipelines by default
         self.fields['pipeline'].initial = models.Pipeline.active.values_list('pk', flat=True)
+        self.fields['default'].initial = self.instance.default
 
     def clean(self):
         cleaned_data = super(LocationForm, self).clean()
@@ -222,6 +225,10 @@ class LocationForm(forms.ModelForm):
         if data not in self.whitelist:
             raise django.core.exceptions.ValidationError(_('Invalid purpose'))
         return data
+
+    def save(self, commit=True):
+        self.instance.default = self.cleaned_data['default']
+        return super(LocationForm, self).save(commit=commit)
 
 
 class ConfirmEventForm(forms.ModelForm):

--- a/storage_service/locations/models/location.py
+++ b/storage_service/locations/models/location.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 # Core Django, alphabetical
+from django.dispatch import receiver
 from django.db import models
 from django.utils.translation import ugettext as _, ugettext_lazy as _l
 
@@ -11,6 +12,7 @@ from django.utils.translation import ugettext as _, ugettext_lazy as _l
 from django_extensions.db.fields import UUIDField
 
 # This project, alphabetical
+from administration.models import Settings
 
 # This module, alphabetical
 from .managers import Enabled
@@ -81,6 +83,12 @@ class Location(models.Model):
     objects = models.Manager()
     active = Enabled()
 
+    # Whether this location is the default location which is a global
+    # application setting stored in administration.models.Settings. See
+    # signal receivers unset_default_locaiton and set_default_location for
+    # more details.
+    _default = False
+
     def __unicode__(self):
         return _('%(uuid)s: %(path)s (%(purpose)s)') % {'uuid': self.uuid, 'purpose': self.get_purpose_display(), 'path': self.relative_path}
 
@@ -91,9 +99,54 @@ class Location(models.Model):
         return os.path.normpath(
             os.path.join(self.space.path, self.relative_path))
 
+    @property
+    def default(self):
+        """ Looks up whether this location is the default one application-wise. """
+        try:
+            name = 'default_{}_location'.format(self.purpose)
+            Settings.objects.get(name=name, value=self.uuid)
+            return True
+        except Settings.DoesNotExist:
+            return False
+
+    @default.setter
+    def default(self, value):
+        self._default = value
+
     def get_description(self):
         """ Returns a user-friendly description (or the path). """
         return self.description or self.full_path
+
+
+@receiver(models.signals.pre_delete, sender=Location)
+def unset_default_location(sender, instance, using, **kwargs):
+    name = 'default_{}_location'.format(instance.purpose)
+    Settings.objects.filter(name=name, value=instance.uuid).delete()
+
+
+@receiver(models.signals.pre_save, sender=Location)
+def set_default_location_pre_save(sender, instance, raw, using, update_fields, **kwargs):
+    # Is this an edit? Has the purpose changed? If both are true, it's possible
+    # that a default location setting with the previous purpose exists and it
+    # needs to be deleted.
+    if not instance.pk:
+        return
+    try:
+        old = Location.objects.get(pk=instance.pk)
+    except Location.DoesNotExist:
+        return
+    if old.purpose != instance.purpose:
+        Settings.objects.filter(
+            name='default_{}_location'.format(old.purpose),
+            value=old.uuid).delete()
+
+@receiver(models.signals.post_save, sender=Location)
+def set_default_location_post_save(sender, instance, created, raw, using, update_fields, **kwargs):
+    name = 'default_{}_location'.format(instance.purpose)
+    if instance._default:
+        Settings.objects.update_or_create(name=name, defaults={'value': instance.uuid})
+    else:
+        Settings.objects.filter(name=name, value=instance.uuid).delete()
 
 
 class LocationPipeline(models.Model):

--- a/storage_service/locations/models/pipeline.py
+++ b/storage_service/locations/models/pipeline.py
@@ -130,6 +130,8 @@ class Pipeline(models.Model):
                     # Fetch existing location
                     location = Location.objects.get(uuid=uuid)
                     assert location.purpose == p['purpose']
+                location.default = True
+                location.save()
                 LOGGER.info("Adding new %s %s to %s",
                     p['purpose'], location, self)
                 LocationPipeline.objects.get_or_create(

--- a/storage_service/templates/locations/location_detail.html
+++ b/storage_service/templates/locations/location_detail.html
@@ -14,6 +14,7 @@
     <dt>{% trans "Relative Path" %}</dt> <dd>{{ location.relative_path }}</dd>
     <dt>{% trans "Usage" %}</dt> <dd>{{ location.used|filesizeformat }} / {{ location.quota|filesizeformat }}</dd>
     <dt>{% trans "Enabled" %}</dt> <dd>{{ location.enabled|yesno:_("Enabled,Disabled") }}</dd>
+    <dt>{% trans "Default" %}</dt> <dd>{{ location.default|yesno:_("Yes,Now") }}</dd>
     <dt>{% trans "Actions" %}</dt>
       <dd>
         <ul>

--- a/storage_service/templates/snippets/locations_table.html
+++ b/storage_service/templates/snippets/locations_table.html
@@ -14,6 +14,7 @@
         <th>{% trans "UUID" %}</th>
         <th>{% trans "Usage" %}</th>
         <th>{% trans "Enabled" %}</th>
+        <th>{% trans "Default" %}</th>
         <th>{% trans "Actions" %}</th>
       </tr>
     </thead>
@@ -38,6 +39,7 @@
         <td>{{ loc.uuid }}</td>
         <td>{{ loc.used }}B / {{ loc.quota|default:_("unlimited") }}</td>
         <td>{{ loc.enabled|yesno:_("Enabled,Disabled") }}</td>
+        <td>{{ loc.default|yesno:_("Yes,No") }}</td>
         <td><a href="{% url 'location_edit' loc.space.uuid loc.uuid %}">{% trans "Edit" %}</a> | <a href="{% url 'location_switch_enabled' loc.uuid %}?next={{ request.path }}">{{ loc.enabled|yesno:_("Disable,Enable") }}</a> | <a href="{% url 'location_delete' loc.uuid %}?next={{ request.path }}">{% trans "Delete" %}</a></td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
Not particularly proud of this PR. It feels a bit hacky even though it took quite a lot of effort to get it working. Suggestions welcome!

I'd liked to consider an alternative based on defaults per pipeline instead - it could be easier to implement as it wouldn't require to deal with external models (`administration.models.Settings`) which are hard to deal with (see signals, post_delete, pre_save, post_save).

---

This commit allows locations to be elected as global defaults for a given
purpose so the client can reference them only by their purpose.
For example: `/api/v2/location/default/AS/` is now possible.

Related issue: https://github.com/JiscRDSS/archivematica/issues/18.