### PR TITLE
Ignore SyntaxError in non-literal settings

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -52,7 +52,10 @@ def get_all_settings():
     """ Returns a dict of 'setting_name': value with all of the settings. """
     settings = dict(models.Settings.objects.all().values_list('name', 'value'))
     for setting, value in settings.items():
-        settings[setting] = ast.literal_eval(value)
+        try:
+            settings[setting] = ast.literal_eval(value)
+        except SyntaxError:
+            pass  # Not all the settings are Python literals
     return settings
 
 


### PR DESCRIPTION
In #8 we used the Settings model to store the default locations in SS. There is
a function used in the administration tab that iterates over all the settings
and expects all the values to be Python literals which are evaluated with
`ast.literal_eval`.

This commits updates the function so it ignores SyntaxError exceptions which
are expected to happen for our new default location settings.