### PR TITLE
Catch SyntaxError and ValueError from literal_eval

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -54,7 +54,7 @@ def get_all_settings():
     for setting, value in settings.items():
         try:
             settings[setting] = ast.literal_eval(value)
-        except SyntaxError:
+        except (SyntaxError, ValueError):
             pass  # Not all the settings are Python literals
     return settings
 


### PR DESCRIPTION
Sometimes `ast.literal_eval` has to evaluate strings which are uuids... either `SyntaxError` or `ValueError` can be raised, depending on how far Python gets through the string before erroring. (so different results for different UUIDs - meaning both should be accounted for)