### PR TITLE
API: add location create endpoint

### DIFF
--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -35,7 +35,7 @@ from administration.models import Settings
 from common import utils
 from locations.api.sword import views as sword_views
 
-from ..models import (Callback, CallbackError, Event, File, Package, Location, Space, Pipeline, StorageException)
+from ..models import (Callback, CallbackError, Event, File, Package, Location, LocationPipeline, Space, Pipeline, StorageException)
 from ..forms import SpaceForm
 from ..constants import PROTOCOL
 from locations import signals
@@ -244,7 +244,6 @@ class SpaceResource(ModelResource):
 class LocationResource(ModelResource):
     space = fields.ForeignKey(SpaceResource, 'space')
     path = fields.CharField(attribute='full_path', readonly=True)
-    description = fields.CharField(attribute='get_description', readonly=True)
     pipeline = fields.ToManyField(PipelineResource, 'pipeline')
 
     class Meta:
@@ -254,8 +253,9 @@ class LocationResource(ModelResource):
         # validation = CleanedDataFormValidation(form_class=LocationForm)
         resource_name = 'location'
 
-        fields = ['enabled', 'relative_path', 'purpose', 'quota', 'used', 'uuid']
-        list_allowed_methods = ['get']
+        fields = ['enabled', 'relative_path', 'purpose', 'quota', 'used',
+                  'uuid', 'description']
+        list_allowed_methods = ['get', 'post']
         detail_allowed_methods = ['get', 'post']
         detail_uri_name = 'uuid'
         always_return_data = True
@@ -267,6 +267,7 @@ class LocationResource(ModelResource):
             'space': ALL_WITH_RELATIONS,
             'used': ALL,
             'uuid': ALL,
+            'description': ALL,
         }
 
     def prepend_urls(self):
@@ -303,6 +304,23 @@ class LocationResource(ModelResource):
             'resource_name': 'location',
             'uuid': uuid,
         }))
+
+    def save_m2m(self, bundle):
+        for field_name, field_object in self.fields.items():
+            if field_name != 'pipeline':
+                continue
+
+            if not getattr(field_object, 'is_m2m', False):
+                continue
+
+            if not field_object.attribute:
+                continue
+
+            pipelines = bundle.data['pipeline']
+            for item in pipelines:
+                LocationPipeline.objects.get_or_create(
+                    pipeline=item.obj,
+                    location=bundle.obj)
 
     @_custom_endpoint(expected_methods=['get'])
     def browse(self, request, bundle, **kwargs):

--- a/storage_service/locations/api/v2.py
+++ b/storage_service/locations/api/v2.py
@@ -22,7 +22,6 @@ class SpaceResource(resources.SpaceResource):
 class LocationResource(resources.LocationResource):
     space = fields.ForeignKey(SpaceResource, 'space')
     path = fields.CharField(attribute='full_path', readonly=True)
-    description = fields.CharField(attribute='get_description', readonly=True)
     pipeline = fields.ToManyField(PipelineResource, 'pipeline')
 
     def decode_path(self, path):

--- a/storage_service/locations/tests/test_api.py
+++ b/storage_service/locations/tests/test_api.py
@@ -28,6 +28,39 @@ class TestLocationAPI(TestCase):
         response = self.client.post('/api/v2/location/213086c8-232e-4b9e-bb03-98fbc7a7966a/')
         assert response.status_code == 401
 
+    def test_create_location(self):
+        space = models.Space.objects.get(
+            uuid='7d20c992-bc92-4f92-a794-7161ff2cc08b')
+        data = {
+            'space': '/api/v2/space/7d20c992-bc92-4f92-a794-7161ff2cc08b/',
+            'description': 'automated workflow',
+            'relative_path': 'automated-workflow/foo/bar',
+            'purpose': 'TS',
+            'pipeline': [
+                '/api/v2/pipeline/b25f6b71-3ebf-4fcc-823c-1feb0a2553dd/'
+            ],
+        }
+
+        response = self.client.post(
+            '/api/v2/location/',
+            data=json.dumps(data),
+            content_type='application/json')
+        assert response.status_code == 201
+
+        # Verify content
+        body = json.loads(response.content)
+        assert body['description'] == data['description']
+        assert body['purpose'] == data['purpose']
+        assert body['path'] == '{}{}'.format(space.path, data['relative_path'])
+        assert body['enabled'] is True
+        assert data['pipeline'][0] in body['pipeline']
+
+        # Verify that the record was populated properly
+        location = models.Location.objects.get(uuid=body['uuid'])
+        assert location.purpose == data['purpose']
+        assert location.relative_path == data['relative_path']
+        assert location.description == data['description']
+
     def test_cant_move_from_non_existant_locations(self):
         data = {
             'origin_location': '/api/v2/location/dne1aacf-8492-4382-8ef3-262cc5420dne/',


### PR DESCRIPTION
Add new `POST /api/v2/location/` endpoint to enable creation of Location
instances given a known space and pipeline. The following is an example on how
it could be used:

#### Find a pipeline

```shell
curl -s \
    -H "Authorization: ApiKey test:test" \
    -H "Content-Type: application/json" \
        "http://127.0.0.1:62081/api/v2/pipeline/" | \
            jq -r ".objects | .[0] | .resource_uri"
```

Result:

    /api/v2/pipeline/90707555-244f-47af-8271-66496a6a965b/

#### Find a space

```shell
curl -s \
    -H "Authorization: ApiKey test:test" \
    -H "Content-Type: application/json" \
        "http://127.0.0.1:62081/api/v2/space/" | \
            jq -r ".objects | .[0] | .resource_uri"
```

Result:

    /api/v2/space/141593ff-2a27-44a1-9de1-917573fa0f4a/

#### Create new location

```shell
curl -s -d '{
    "pipeline": ["/api/v2/pipeline/90707555-244f-47af-8271-66496a6a965b/"],
    "purpose": "TS",
    "relative_path": "automated-workflow/foo/bar",
    "description": "automated workflow",
    "space": "/api/v2/space/141593ff-2a27-44a1-9de1-917573fa0f4a/"
}' \
    -X POST \
    -H "Authorization: ApiKey test:test" \
    -H "Content-Type: application/json" \
        "http://127.0.0.1:62081/api/v2/location/" | \
            jq -r ".resource_uri"
```

Result:

    /api/v2/location/693f8fa4-744a-4c8f-9e1f-275d422e3bad/

#### Inspect location

```shell
curl -s \
    -H "Authorization: ApiKey test:test" \
    -H "Content-Type: application/json" \
        "http://127.0.0.1:62081/api/v2/location/693f8fa4-744a-4c8f-9e1f-275d422e3bad/" | jq
```

Result:

```json
{
  "description": "automated workflow",
  "enabled": true,
  "path": "/automated-workflow/foo/bar",
  "pipeline": [
    "/api/v2/pipeline/90707555-244f-47af-8271-66496a6a965b/"
  ],
  "purpose": "TS",
  "quota": null,
  "relative_path": "automated-workflow/foo/bar",
  "resource_uri": "/api/v2/location/693f8fa4-744a-4c8f-9e1f-275d422e3bad/",
  "space": "/api/v2/space/141593ff-2a27-44a1-9de1-917573fa0f4a/",
  "used": "0",
  "uuid": "693f8fa4-744a-4c8f-9e1f-275d422e3bad"
}
```